### PR TITLE
restrict altair version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,13 @@ EMAIL = "mail@jan-matthis.de"
 AUTHOR = "Jan-Matthis Lueckmann"
 REQUIRES_PYTHON = ">=3.6.0"
 
-REQUIRED = ["altair", "altair_saver", "flatlatex", "mergedeep", "vega_datasets"]
+REQUIRED = [
+    "altair<=4.2.0", 
+    "altair_saver", 
+    "flatlatex", 
+    "mergedeep", 
+    "vega_datasets",
+]
 EXTRAS = {
     "dev": ["autoflake", "black", "flake8", "ipdb", "isort", "pytest"],
 }


### PR DESCRIPTION
version 5.0.0 causes the following bug in sbibm.

```
Traceback (most recent call last):              
  File "results/train.py", line 12, in <module>                                                      
    from misbi import configtools        
  File "/home/ben/sci/next/src/misbi/configtools.py", line 7, in <module>
    from sbibm.visualisation.posterior import _LIMITS_
  File "/home/ben/sci/next/remote/sbibm/sbibm/visualisation/__init__.py", line 1, in <module>
    from .correlation import fig_correlation
  File "/home/ben/sci/next/remote/sbibm/sbibm/visualisation/correlation.py", line 4, in <module>                                                                                                           
    import deneb as den                  
  File "/home/ben/mambaforge/envs/next38/lib/python3.8/site-packages/deneb/__init__.py", line 4, in <module>
    from .correlation_matrix import correlation_matrix
  File "/home/ben/mambaforge/envs/next38/lib/python3.8/site-packages/deneb/correlation_matrix.py", line 6, in <module>
    from .utils import Chart         
  File "/home/ben/mambaforge/envs/next38/lib/python3.8/site-packages/deneb/utils.py", line 11, in <module>
    Chart = alt.vegalite.v4.api.Chart
AttributeError: module 'altair.vegalite' has no attribute 'v4'
```

It must be restricted.